### PR TITLE
fix: 피드백게시물 조회 -> 게시물, 날짜별 수입지출 개수 반환

### DIFF
--- a/src/main/java/kb/zango/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/kb/zango/domain/comment/service/CommentServiceImpl.java
@@ -6,7 +6,6 @@ import kb.zango.domain.board.repository.BoardRepository;
 import kb.zango.domain.comment.dto.CreateCommentRequestDTO;
 import kb.zango.domain.comment.dto.CommentResponseDTO;
 import kb.zango.domain.comment.dto.UpdateCommentRequestDTO;
-import kb.zango.domain.comment.entity.Comment;
 import kb.zango.domain.comment.repository.CommentRepository;
 import kb.zango.domain.users.entity.User;
 import kb.zango.domain.users.repository.UserRepository;

--- a/src/main/java/kb/zango/domain/diary/feedBack/dto/IOCntByDate.java
+++ b/src/main/java/kb/zango/domain/diary/feedBack/dto/IOCntByDate.java
@@ -1,17 +1,16 @@
 package kb.zango.domain.diary.feedBack.dto;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class FeedBackResponseDTO {
+public class IOCntByDate {
 
-    private GetBoardDTO board;
-    private List<IOCntByDate> ioCnts;
-
+    private String date; // 날짜
+    private int incomeCnt;  // 수입 개수
+    private int outcomeCnt; // 지출 개수
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 피드백게시물 조회 -> 게시물, 날짜별 수입지출 개수 반환

## 📝작업 내용

> 피드백게시물 조회 -> 게시물, 날짜별 수입지출 개수 반환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
